### PR TITLE
Use brace matching to determine when to split up JSON data

### DIFF
--- a/gnip-stream.gemspec
+++ b/gnip-stream.gemspec
@@ -5,14 +5,12 @@ require 'gnip-stream/version'
 Gem::Specification.new do |s|
   s.name        = 'gnip-stream'
   s.version     = GnipStream::VERSION
-  s.authors     = ['Ryan Weald']
-  s.email       = ['ryan@weald.com']
-  s.homepage    = 'https://github.com/rweald/gnip-stream'
+  s.authors     = ['Altmetric']
+  s.email       = ['support@altmetric.com']
+  s.homepage    = 'https://github.com/altmetric/gnip-stream'
   s.summary     = 'A library to connect and stream data from the GNIP streaming API'
-  s.description = ''
+  s.description = 'Based on a fork of https://github.com/rweald/gnip-stream'
   s.license = 'MIT'
-
-  s.rubyforge_project = 'gnip-stream'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/gnip-stream/json_data_buffer.rb
+++ b/lib/gnip-stream/json_data_buffer.rb
@@ -1,9 +1,9 @@
 module GnipStream
   class JsonDataBuffer
-    attr_accessor :split_pattern, :check_pattern
-    def initialize(split_pattern, check_pattern)
-      @split_pattern = split_pattern
-      @check_pattern = check_pattern
+    JSON_BRACE_MATCHING = /(?<match>\{(?:\g<match>|[^{}]++)*\})(?<excess>.*\Z)/m
+    attr_accessor :buffer
+
+    def initialize
       @buffer = ''
     end
 
@@ -13,10 +13,9 @@ module GnipStream
 
     def complete_entries
       entries = []
-      while @buffer =~ check_pattern
-        activities = @buffer.split(split_pattern)
-        entries << activities.shift
-        @buffer = activities.join(split_pattern)
+      while (look_for_json = @buffer.match(JSON_BRACE_MATCHING))
+        entries << look_for_json[:match]
+        @buffer = look_for_json[:excess]
       end
 
       entries

--- a/lib/gnip-stream/json_stream.rb
+++ b/lib/gnip-stream/json_stream.rb
@@ -4,7 +4,7 @@ module GnipStream
   class JsonStream
     include StreamDelegate
     def initialize(url, headers = {})
-      json_processor = JsonDataBuffer.new("\r\n", Regexp.new(/^.*\r\n/))
+      json_processor = JsonDataBuffer.new
       @stream = Stream.new(url, json_processor, headers)
     end
   end

--- a/lib/gnip-stream/version.rb
+++ b/lib/gnip-stream/version.rb
@@ -1,3 +1,3 @@
 module GnipStream
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/spec/gnip-stream/json_data_buffer_spec.rb
+++ b/spec/gnip-stream/json_data_buffer_spec.rb
@@ -2,36 +2,36 @@ require 'spec_helper'
 require 'gnip-stream/json_data_buffer'
 
 describe GnipStream::JsonDataBuffer do
-  let(:json_buffer) { GnipStream::JsonDataBuffer.new("\r\n", Regexp.new(/^.*\r\n/)) }
-  describe '#initialize' do
-    it 'accepts a regex pattern that will be used to match complete entries' do
-      split_pattern = "\n"
-      check_pattern = /hello\r\n/
-      expect(GnipStream::JsonDataBuffer.new(split_pattern, check_pattern).check_pattern).to eq(check_pattern)
-      expect(GnipStream::JsonDataBuffer.new(split_pattern, check_pattern).split_pattern).to eq(split_pattern)
-    end
-  end
-
   describe '#process' do
-    it 'appends the data to the buffer' do
-      json_buffer.process("hello\r\nother")
-      expect(json_buffer.instance_variable_get(:@buffer)).to eq("hello\r\nother")
+    it 'appends the data to an internal buffer' do
+      json_buffer = GnipStream::JsonDataBuffer.new
+      json_buffer.process('foo')
+      json_buffer.process('bar')
+
+      expect(json_buffer.buffer).to eq('foobar')
     end
   end
 
   describe '#complete_entries' do
-    it 'returns a list of complete entries' do
-      json_buffer.process("hello\r\nother")
-      expect(json_buffer.complete_entries).to eq(['hello'])
-      expect(json_buffer.instance_variable_get(:@buffer)).to eq('other')
-    end
-  end
+    it 'correctly parses out each message into a separate entry' do
+      json_buffer = GnipStream::JsonDataBuffer.new
 
-  describe '#multiple complete_entries' do
-    it 'returns a list of complete entries' do
-      json_buffer.process("hello\r\nhello2\r\nhello3\r\nhel")
-      expect(json_buffer.complete_entries).to eq(%w(hello hello2 hello3))
-      expect(json_buffer.instance_variable_get(:@buffer)).to eq('hel')
+      json_buffer.process('{"message": "a", "status": {"ok": true}}{"message": "b", "options": [true, false]}')
+      json_buffer.process("\r\n{\"message\": \"partial\"")
+
+      expect(json_buffer.complete_entries).to eq(['{"message": "a", "status": {"ok": true}}', '{"message": "b", "options": [true, false]}'])
+    end
+
+    it 'does not include blank lines' do
+      json_buffer = GnipStream::JsonDataBuffer.new
+
+      input_stream = '{"message": "a", "status": {"ok": true}}'
+      input_stream += "\r\n\r\n"
+      input_stream += '{"message": "b", "options": [true, false]}'
+      input_stream += "\r\n{\"message\": \"partial\""
+
+      json_buffer.process(input_stream)
+      expect(json_buffer.complete_entries).to eq(['{"message": "a", "status": {"ok": true}}', '{"message": "b", "options": [true, false]}'])
     end
   end
 end


### PR DESCRIPTION
On some inputs, most notably the compliance firehose data, it appeared that splitting input on each '\r\n' combination meant that individual methods actually included more than one JSON object.

This fix uses a brace-matching Regex to grab JSON packets based on them always beginning and ending with `{` and `}`, and with any opening braces within also having a matching closing brace.

By looking for this combination of factors, each element of the array returned by `complete entries` should be a JSON object. It also means that multiple `\r\n` sequences, for example as sent by GNIP to keep the connection alive, do not get sent on.
