### PR TITLE
Bump up buffer limit to accomodate larger tweets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,1 @@
 script: "bundle exec rspec spec/"
-
-addons:
-  code_climate:
-    repo_token: b8d249edd78c476c53322c4f02937d8977a631e72130e8b71512b325b6a7d72c

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # gnip-stream
 [![Build Status](https://secure.travis-ci.org/altmetric/gnip-stream.png)](http://travis-ci.org/altmetric/gnip-stream)
-[![Code Climate](https://codeclimate.com/github/altmetric/gnip-stream/badges/gpa.svg)](https://codeclimate.com/github/altmetric/gnip-stream)
-[![Test Coverage](https://codeclimate.com/github/altmetric/gnip-stream/badges/coverage.svg)](https://codeclimate.com/github/altmetric/gnip-stream/coverage)
 
 gnip-stream is a ruby library to connect and stream data from [GNIP](http://gnip.com/). It utilizes EventMachine and threads under the hood to provide a true streaming experience without you having to worry about writing non blocking code.
 

--- a/gnip-stream.gemspec
+++ b/gnip-stream.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.3'
   s.add_development_dependency 'guard'
   s.add_development_dependency 'guard-rspec'
-  s.add_development_dependency 'codeclimate-test-reporter'
   s.add_development_dependency 'dotenv'
 
   s.add_dependency 'em-http-request', '>= 1.0.3'

--- a/lib/gnip-stream/json_data_buffer.rb
+++ b/lib/gnip-stream/json_data_buffer.rb
@@ -7,7 +7,7 @@ module GnipStream
     attr_reader :maximum_size
     private :maximum_size
 
-    def initialize(maximum_size: 200_000)
+    def initialize(maximum_size: 250_000)
       @buffer = ''
       @maximum_size = maximum_size
     end

--- a/lib/gnip-stream/version.rb
+++ b/lib/gnip-stream/version.rb
@@ -1,3 +1,3 @@
 module GnipStream
-  VERSION = '2.0.2'
+  VERSION = '2.0.3'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,9 +4,4 @@ Bundler.setup
 require 'dotenv'
 Dotenv.load
 
-if ENV['CODECLIMATE_REPO_TOKEN']
-  require 'codeclimate-test-reporter'
-  CodeClimate::TestReporter.start
-end
-
 require 'rspec'


### PR DESCRIPTION
We have encountered tweets with very large descriptions. Bump up limit
to accomodate those